### PR TITLE
Use backend to send faro data

### DIFF
--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -1,0 +1,51 @@
+name: On push main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract tag from last conventional commit
+        id: extract_tag
+        run: |
+          commit_message=$(git log -1 --pretty=%B)
+          if [[ $commit_message =~ ^(feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert|other)(\([^)]+\))?: ]]; then
+            tag_type=${BASH_REMATCH[1]}
+            tag=$(echo $commit_message | grep -oE '([0-9]+\.[0-9]+\.[0-9]+)' | head -n1)
+            if [[ -z $tag ]]; then
+              tag=$(date +'%Y%m%d%H%M%S')
+            fi
+            echo "tag=$tag_type-$tag" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.extract_tag.outputs.tag }}
+            ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev
+COPY . .
+RUN ls -la
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app .
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/components/frontend-observability.tsx
+++ b/components/frontend-observability.tsx
@@ -11,7 +11,7 @@ export default function FrontendObservability(){
 
   try {
     const faro = initializeFaro({
-      url: process.env.NEXT_PUBLIC_FARO_URL,
+      url: "/api/faro",
       app: {
         name: process.env.NEXT_PUBLIC_FARO_APP_NAME || 'unknown_service:webjs',
         namespace: process.env.NEXT_PUBLIC_FARO_APP_NAMESPACE || undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nextjs-blog",
+  "name": "faro-nextjs-example",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "next dev",
+    "dev": "next dev -p 3001",
     "start": "next start"
   },
   "dependencies": {

--- a/pages/api/faro.ts
+++ b/pages/api/faro.ts
@@ -1,0 +1,29 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    // Format headers to be compatible with fetch
+    const headers = new Headers();
+    Object.entries(req.headers).forEach(([key, value]) => {
+      if (value) headers.append(key, Array.isArray(value) ? value.join(', ') : value);
+    });
+    // Forward to grafana faro
+    const response = await fetch(process.env.NEXT_PUBLIC_FARO_URL || '', {
+      method: req.method,
+      headers,
+      body: req.body ? JSON.stringify(req.body) : undefined,
+    });
+
+    // Send response to client
+    const contentType = response.headers.get('content-type');
+    if (contentType && contentType.includes('application/json')) {
+      const data = await response.json();
+      return res.status(response.status).json(data);
+    } else {
+      const text = await response.text();
+      return res.status(response.status).send(text);
+    }
+  } catch (error: any) {
+    return res.status(500).json({ error: error.message });
+  }
+}

--- a/pages/repo/[...repo].js
+++ b/pages/repo/[...repo].js
@@ -1,5 +1,5 @@
 import { fetchGithubStars } from "../../shared/fetchGithubStars";
-import Layout from "../../components/Layout";
+import Layout from "../../components/layout";
 import Head from "next/head";
 import styles from "../../styles/Home.module.css";
 import opentelemetry from "@opentelemetry/api";


### PR DESCRIPTION
# Use FARO API Endpoint to send Faro data to Grafana
## Description
This pull request imlements a proxy via `pages/api/faro.ts` file that use the NEXT_PUBLIC_FARO_URL environment variable. This change enhances the security of the application by preventing the FARO URL from being exposed in the browser.

## Changes Made
Create a proxy in `pages/api/faro.ts`.

## Benefits
**Security**
The faro url is no longer exposed in the client-side code, reducing the risk of it being accessed or misused by unauthorized parties.

**CORS**
Since the browser is no longer responsible for sending requests to Faro, CORS issues are no longer an issue.

## Testing
- Verify that the application correctly forwards requests to the FARO endpoint using the environment variable.