### PR TITLE
Add "isClient" check to frontend observability

### DIFF
--- a/components/frontend-observability.tsx
+++ b/components/frontend-observability.tsx
@@ -3,9 +3,11 @@
 import { faro, getWebInstrumentations, initializeFaro } from '@grafana/faro-web-sdk';
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
 
+const isClient = typeof window !== 'undefined';
+
 export default function FrontendObservability(){
-  // skip if already initialized
-  if (faro.api) {
+  // skip if already initialized or if not in a browser environment
+  if (!isClient || faro.api) {
     return null;
   }
 


### PR DESCRIPTION
Nextjs will try to render client components on the server or stream them during any revalidation of client cache. The TracingInstrumentation() uses zonejs and is known to cause issues with how next handles this client/server relationship.

In the app router specifically, if a server action was used to set or modify cookies, the resulting RSC payload would fail with this setup. 

After many, many hours of trying to track down why nextjs started throwing a "cookies() was not part of the request context error" in a large repo, it turned out it was the TracingInstrumentation() part of this specifically when not specifically limited to the client. Adding the "window !== undefined" fixed the issue for us and may for others.